### PR TITLE
State compatibility with new Quasar versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quasar-app-extension-dotenv-plus",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A dotenv wrapper for Quasar apps",
   "author": "sirkrypt0",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -53,8 +53,8 @@ module.exports = function (api) {
   // Quasar compatibility check; you may need
   // hard dependencies, as in a minimum version of the "quasar"
   // package or a minimum version of "@quasar/app" CLI
-  api.compatibleWith('quasar', '^1.1.1')
-  api.compatibleWith('@quasar/app', '^2.0.0')
+  api.compatibleWith('quasar', '^1.1.1 || ^2.0.0 || ^2.0.0-beta')
+  api.compatibleWith('@quasar/app', '^2.0.0 || ^3.0.0 || ^3.0.0-beta')
 
 
   // We extend /quasar.conf.js


### PR DESCRIPTION
Tested the current code base against those packages:

```
Pkg quasar........ v2.0.0-beta.7
Pkg @quasar/app... v3.0.0-beta.7
```

These are working fine, so I suspect that the final versions will do as well (that's why I enabled them right along).

At some point in the future we could remove the beta packages again I think.